### PR TITLE
Add audio speed up / slow down

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/Format.java
+++ b/src/main/java/uk/yermak/audiobookconverter/Format.java
@@ -279,8 +279,16 @@ public enum Format {
         return List.of(8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 192, 224, 256, 320);
     }
 
+    public List<Double> speeds() {
+        return List.of(0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0);
+    }
+
     public Integer defaultBitrate() {
         return 128;
+    }
+
+    public Double defaultSpeed() {
+        return 1.0;
     }
 
     public Integer defaultChannel() {
@@ -352,6 +360,11 @@ public enum Format {
         }
         options.add("-f");
         options.add(format);
+
+        if (outputParameters.getSpeed() != 1.0) {
+            options.add("-filter:a");
+            options.add("atempo=" + outputParameters.getSpeed());
+        }
 
         options.add("-progress");
         options.add(progressUri);

--- a/src/main/java/uk/yermak/audiobookconverter/OutputParameters.java
+++ b/src/main/java/uk/yermak/audiobookconverter/OutputParameters.java
@@ -8,6 +8,7 @@ public class OutputParameters {
 
     protected Format format = Format.M4B;
     protected Integer bitRate = format.defaultBitrate();
+    protected Double speed = format.defaultSpeed();
     protected Integer frequency = format.defaultFrequency();
     protected Integer channels = format.defaultChannel();
     protected Integer vbrQuality = format.defaultVbrQuality();
@@ -19,6 +20,7 @@ public class OutputParameters {
 
     public OutputParameters(OutputParameters parameters) {
         this.bitRate = parameters.getBitRate();
+        this.speed = parameters.getSpeed();
         this.frequency = parameters.getFrequency();
         this.channels = parameters.getChannels();
         this.vbrQuality = parameters.getVbrQuality();
@@ -33,6 +35,7 @@ public class OutputParameters {
     OutputParameters(Format format, int bitRate, int frequency, int channels, int cutoff, boolean cbr, int quality) {
         this.format = format;
         this.bitRate = bitRate;
+        this.speed = format.defaultSpeed();
         this.frequency = frequency;
         this.channels = channels;
         this.vbrQuality = quality;
@@ -55,6 +58,14 @@ public class OutputParameters {
 
     public void setBitRate(final Integer bitRate) {
         this.bitRate = bitRate;
+    }
+
+    public Double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(final Double speed) {
+        this.speed = speed;
     }
 
     public Integer getFrequency() {

--- a/src/main/java/uk/yermak/audiobookconverter/fx/OutputController.java
+++ b/src/main/java/uk/yermak/audiobookconverter/fx/OutputController.java
@@ -32,6 +32,9 @@ public class OutputController {
     @FXML
     private ComboBox<String> splitFileBox;
 
+    @FXML
+    private ComboBox<String> speedBox;
+
 
     @FXML
     public ComboBox<String> cutoff;
@@ -76,6 +79,11 @@ public class OutputController {
             }
         });
 
+        speedBox.valueProperty().addListener((observableValue, oldValue, newValue) -> {
+            if (newValue == null) return;
+            ConverterApplication.getContext().getOutputParameters().setSpeed(Double.valueOf(newValue));
+        });
+
         outputFormatBox.getItems().addAll(Format.values());
         outputFormatBox.getSelectionModel().select(0);
         outputFormatBox.getSelectionModel().selectedItemProperty().addListener((observableValue, oldValue, newValue) -> {
@@ -105,6 +113,7 @@ public class OutputController {
                 Preset preset = Preset.instance(newValue);
                 ConverterApplication.getContext().setOutputParameters(preset);
             }
+            refreshSpeeds();
         });
 
         ConverterApplication.getContext().addOutputParametersChangeListener((observableValue, oldParams, newParams) -> {
@@ -125,6 +134,7 @@ public class OutputController {
         refreshCutoffs();
         refreshVbrQuality();
         refreshCBR();
+        refreshSpeeds();
 
         ConversionContext context = ConverterApplication.getContext();
         media = context.getMedia();
@@ -218,6 +228,13 @@ public class OutputController {
         bitRate.getItems().clear();
         bitRate.getItems().addAll(ConverterApplication.getContext().getOutputParameters().getFormat().bitrates().stream().map(String::valueOf).collect(Collectors.toList()));
         bitRate.getSelectionModel().select(String.valueOf(format.defaultBitrate()));
+    }
+
+    private void refreshSpeeds() {
+        Format format = ConverterApplication.getContext().getOutputParameters().getFormat();
+        speedBox.getItems().clear();
+        speedBox.getItems().addAll(ConverterApplication.getContext().getOutputParameters().getFormat().speeds().stream().map(String::valueOf).collect(Collectors.toList()));
+        speedBox.getSelectionModel().select(String.valueOf(format.defaultSpeed()));
     }
 
     private void refreshFrequencies() {

--- a/src/main/resources/uk/yermak/audiobookconverter/fx/output.fxml
+++ b/src/main/resources/uk/yermak/audiobookconverter/fx/output.fxml
@@ -57,6 +57,9 @@
             </items>
         </ComboBox>
 
+        <Label text="Speed" textAlignment="LEFT" GridPane.columnIndex="0" GridPane.rowIndex="3"/>
+        <ComboBox fx:id="speedBox" GridPane.columnIndex="1" GridPane.rowIndex="3" GridPane.halignment="RIGHT"/>
+
 
         <Pane prefWidth="50" GridPane.columnIndex="2" GridPane.rowIndex="0" GridPane.rowSpan="3"/>
 


### PR DESCRIPTION
Some audiobooks are so slow that even x2 mode in iBooks doesn't make it better enough.
So, I've added a feature to change the audio tempo using `atempo` filter:
http://ffmpeg.org/ffmpeg-all.html#atempo

![image](https://user-images.githubusercontent.com/10179350/106127936-0438e100-6170-11eb-96b9-37903d2bacb8.png)
