### PR TITLE
Initialize logger before using it when loading properties

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/Platform.java
+++ b/src/main/java/uk/yermak/audiobookconverter/Platform.java
@@ -42,6 +42,9 @@ public enum Platform {
         }
     };
     static Platform current;
+
+    final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     private static Properties properties = new Properties();
 
     static {
@@ -51,8 +54,6 @@ public enum Platform {
         if (DEV.isDebug()) current = DEV;
         properties = current.loadAppProperties();
     }
-
-    final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 
     public static final String FFPROBE = current.getPath("ffprobe");


### PR DESCRIPTION
The line immediately above the line where the logger is initialized (`properties = current.loadAppProperties();` can cause logging to occur.  With `logger` not initialized this throws a NPE, but this happens in a static initializer and causes the class to not load, producing a `NoClassDefFoundError` instead of a more helpful stack trace.

As far as I've experienced the bug, this fixes #380