### PR TITLE
Localize chooser titles

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/AudiobookConverter.java
+++ b/src/main/java/uk/yermak/audiobookconverter/AudiobookConverter.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 
 public class AudiobookConverter extends Application {
     private static JfxEnv env;
+    private static ResourceBundle bundle;
 
     //TODO clean-up
     static {
@@ -89,7 +90,7 @@ public class AudiobookConverter extends Application {
         logger.info("Initialising application");
 
         Locale defaultLocale = Locale.getDefault();
-        ResourceBundle bundle = getBundleWithFallback(defaultLocale);
+        bundle = getBundleWithFallback(defaultLocale);
 
         try {
             URL resource = AudiobookConverter.class.getResource("/uk/yermak/audiobookconverter/fx/fxml_converter.fxml");
@@ -132,6 +133,10 @@ public class AudiobookConverter extends Application {
             logger.error("Error initiating application", e);
             e.printStackTrace();
         }
+    }
+
+    public static ResourceBundle getBundle() {
+        return bundle;
     }
 
     public static void loadHints() throws IOException {

--- a/src/main/java/uk/yermak/audiobookconverter/fx/ArtWorkController.java
+++ b/src/main/java/uk/yermak/audiobookconverter/fx/ArtWorkController.java
@@ -24,6 +24,8 @@ import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
 
 /**
  * Created by yermak on 03-Dec-18.
@@ -34,6 +36,9 @@ public class ArtWorkController {
     ListView<ArtWork> imageList;
 
     final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @FXML
+    private ResourceBundle resources;
 
     @FXML
     private void initialize() {
@@ -48,7 +53,12 @@ public class ArtWorkController {
         FileChooser fileChooser = new FileChooser();
         File sourceFolder = Settings.loadSetting().getSourceFolder();
         fileChooser.setInitialDirectory(sourceFolder);
-        fileChooser.setTitle("Select JPG or PNG file");
+        ResourceBundle bundle = resources != null ? resources : AudiobookConverter.getBundle();
+        String fileTypes = "JPG, PNG, BMP";
+        String title = bundle != null
+                ? MessageFormat.format(bundle.getString("chooser.select_image"), fileTypes)
+                : MessageFormat.format("Select {0} file", fileTypes);
+        fileChooser.setTitle(title);
         fileChooser.getExtensionFilters().addAll(
                 new FileChooser.ExtensionFilter("jpg", "*.jpg", "*.jpeg", "*.jfif"),
                 new FileChooser.ExtensionFilter("png", "*.png"),

--- a/src/main/java/uk/yermak/audiobookconverter/fx/DialogHelper.java
+++ b/src/main/java/uk/yermak/audiobookconverter/fx/DialogHelper.java
@@ -17,6 +17,7 @@ import uk.yermak.audiobookconverter.fx.util.Comparators;
 
 import java.io.File;
 import java.lang.invoke.MethodHandles;
+import java.text.MessageFormat;
 import java.util.*;
 
 public class DialogHelper {
@@ -43,7 +44,9 @@ public class DialogHelper {
         File outputFolder = Settings.loadSetting().getOutputFolder();
         fileChooser.setInitialDirectory(outputFolder);
         fileChooser.setInitialFileName(Utils.getOuputFilenameSuggestion(audioBookInfo));
-        fileChooser.setTitle("Save AudioBook");
+        ResourceBundle bundle = AudiobookConverter.getBundle();
+        String title = bundle != null ? bundle.getString("chooser.save_audiobook") : "Save AudioBook";
+        fileChooser.setTitle(title);
         String formatAsString = AudiobookConverter.getContext().getFormat().toString();
         fileChooser.getExtensionFilters().addAll(
                 new FileChooser.ExtensionFilter(formatAsString, "*." + formatAsString)
@@ -68,7 +71,11 @@ public class DialogHelper {
 
         Arrays.stream(FILE_EXTENSIONS).map(String::toUpperCase).forEach(filetypes::add);
 
-        fileChooser.setTitle("Select " + filetypes + " files for conversion");
+        ResourceBundle bundle = AudiobookConverter.getBundle();
+        String title = bundle != null
+                ? MessageFormat.format(bundle.getString("chooser.select_files"), filetypes)
+                : MessageFormat.format("Select {0} files for conversion", filetypes);
+        fileChooser.setTitle(title);
 
         fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Audio", Arrays.asList(toSuffixes("*.", FILE_EXTENSIONS))));
 
@@ -97,7 +104,11 @@ public class DialogHelper {
 
         Arrays.stream(FILE_EXTENSIONS).map(String::toUpperCase).forEach(filetypes::add);
 
-        directoryChooser.setTitle("Select folder with " + filetypes + " files for conversion");
+        ResourceBundle bundle = AudiobookConverter.getBundle();
+        String title = bundle != null
+                ? MessageFormat.format(bundle.getString("chooser.select_folder"), filetypes)
+                : MessageFormat.format("Select folder with {0} files for conversion", filetypes);
+        directoryChooser.setTitle(title);
         File selectedDirectory = directoryChooser.showDialog(window);
 
         if (selectedDirectory == null) return null;

--- a/src/main/resources/locales/messages_en.properties
+++ b/src/main/resources/locales/messages_en.properties
@@ -146,3 +146,7 @@ chapters.tooltip.button_start=Start conversion of the book
 bookinfo.tooltip.tab=Fill information about the book it will be shown in book players
 artwork.tooltip.tab=Add artworks to the book to be displayed in book players
 output.tooltip.tab=Fine-tune quality and size of the audibook
+chooser.save_audiobook=Save AudioBook
+chooser.select_files=Select {0} files for conversion
+chooser.select_folder=Select folder with {0} files for conversion
+chooser.select_image=Select {0} file


### PR DESCRIPTION
## Summary
- use the application resource bundle for chooser titles and support message formatting
- localize the artwork image chooser title with bundle-based text
- add new chooser strings to the English locale properties file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b276a5850832096738d4cde916bad)