### PR TITLE
Use localized chapter titles

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/loaders/FFMediaLoader.java
+++ b/src/main/java/uk/yermak/audiobookconverter/loaders/FFMediaLoader.java
@@ -45,8 +45,9 @@ public class FFMediaLoader {
             FFprobe ffprobe = new FFprobe(Platform.FFPROBE);
             logger.info("FFprobe created: " + ffprobe.getPath());
             List<MediaInfo> media = new ArrayList<>();
+            ResourceBundle bundle = AudiobookConverter.getBundle();
             for (String fileName : fileNames) {
-                Future<MediaInfo> futureLoad = mediaExecutor.submit(new MediaInfoLoader(ffprobe, fileName, conversionGroup));
+                Future<MediaInfo> futureLoad = mediaExecutor.submit(new MediaInfoLoader(ffprobe, fileName, conversionGroup, bundle));
                 logger.info("MediaLoader submitted for file:" + fileName);
                 MediaInfo mediaInfo = new MediaInfoProxy(fileName, futureLoad);
                 media.add(mediaInfo);

--- a/src/main/java/uk/yermak/audiobookconverter/loaders/MediaInfoLoader.java
+++ b/src/main/java/uk/yermak/audiobookconverter/loaders/MediaInfoLoader.java
@@ -14,12 +14,14 @@ import org.slf4j.LoggerFactory;
 import uk.yermak.audiobookconverter.ConversionGroup;
 import uk.yermak.audiobookconverter.book.*;
 
+import java.text.MessageFormat;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.ResourceBundle;
 
 class MediaInfoLoader implements Callable<MediaInfo> {
 
@@ -33,14 +35,16 @@ class MediaInfoLoader implements Callable<MediaInfo> {
     private final String filename;
     private final ConversionGroup conversionGroup;
     private final FFprobe ffprobe;
+    private final ResourceBundle resources;
 
     private static final ScheduledExecutorService artExecutor = Executors.newScheduledThreadPool(8);
 
 
-    public MediaInfoLoader(FFprobe ffprobe, String filename, ConversionGroup conversionGroup) {
+    public MediaInfoLoader(FFprobe ffprobe, String filename, ConversionGroup conversionGroup, ResourceBundle resources) {
         this.ffprobe = ffprobe;
         this.filename = filename;
         this.conversionGroup = conversionGroup;
+        this.resources = resources;
     }
 
     @Override
@@ -125,7 +129,7 @@ class MediaInfoLoader implements Callable<MediaInfo> {
             if (chapter.tags != null) {
                 track.setTitle(chapter.tags.title);
             } else {
-                track.setTitle("Chapter " + trackNo);
+                track.setTitle(MessageFormat.format(resources.getString("chapter.default_title"), trackNo));
             }
             track.setStart((long) (Double.parseDouble(chapter.start_time) * 1000));
             track.setEnd((long) (Double.parseDouble(chapter.end_time) * 1000));

--- a/src/main/resources/locales/messages_en.properties
+++ b/src/main/resources/locales/messages_en.properties
@@ -156,3 +156,4 @@ chooser.save_audiobook=Save AudioBook
 chooser.select_files=Select {0} files for conversion
 chooser.select_folder=Select folder with {0} files for conversion
 chooser.select_image=Select {0} file
+chapter.default_title=Chapter {0}


### PR DESCRIPTION
## Summary
- add a localized default chapter title template with numbering placeholder
- update MediaInfoLoader to format default chapter names using the resource bundle
- pass the application resource bundle into MediaInfoLoader for localization

## Testing
- mvn -q -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b297c49c48320a6388af788fad9d5)