### PR TITLE
Localize optimizer progress status

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/ConversionJob.java
+++ b/src/main/java/uk/yermak/audiobookconverter/ConversionJob.java
@@ -88,7 +88,7 @@ public class ConversionJob implements Runnable {
 
             if (getConversionGroup().getOutputParameters().getFormat().mp4Compatible()) {
                 try {
-                    String optimisedOutput = new FFMpegOptimizer(this, tempFile, outputDestination, progressCallbacks.get("output")).optimize();
+                    String optimisedOutput = new FFMpegOptimizer(this, tempFile, outputDestination, progressCallbacks.get("output"), AudiobookConverter.getBundle()).optimize();
                     if (destFile.exists()) FileUtils.deleteQuietly(destFile);
                     FileUtils.moveFile(new File(optimisedOutput), destFile);
                 } finally {

--- a/src/main/java/uk/yermak/audiobookconverter/FFMpegOptimizer.java
+++ b/src/main/java/uk/yermak/audiobookconverter/FFMpegOptimizer.java
@@ -11,11 +11,13 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
+import java.util.ResourceBundle;
 import java.util.concurrent.TimeUnit;
 
 public class FFMpegOptimizer {
     final static Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private final ConversionJob conversionJob;
+    private final ResourceBundle resources;
 
     private String tempFile;
     private final String outputFileName;
@@ -23,19 +25,19 @@ public class FFMpegOptimizer {
 
     private ProgressParser progressParser;
 
-
-    public FFMpegOptimizer(ConversionJob conversionJob, String tempFile, String outputFileName, ProgressCallback callback) {
+    public FFMpegOptimizer(ConversionJob conversionJob, String tempFile, String outputFileName, ProgressCallback callback, ResourceBundle resources) {
         this.conversionJob = conversionJob;
         this.tempFile = tempFile;
         this.outputFileName = outputFileName;
         this.callback = callback;
+        this.resources = resources;
     }
 
 
     String optimize() throws InterruptedException, IOException {
         while (ProgressStatus.PAUSED.equals(conversionJob.getStatus())) Thread.sleep(1000);
         callback.reset();
-        callback.setState("Optimising...");
+        callback.setState(resources.getString("progress.state.optimizing"));
         try {
             progressParser = new TcpProgressParser(progress -> {
                 callback.converted(progress.out_time_ns / 1000000, progress.total_size);

--- a/src/main/resources/locales/messages_en.properties
+++ b/src/main/resources/locales/messages_en.properties
@@ -167,3 +167,5 @@ chooser.select_files=Select {0} files for conversion
 chooser.select_folder=Select folder with {0} files for conversion
 chooser.select_image=Select {0} file
 chapter.default_title=Chapter {0}
+
+progress.state.optimizing=Optimising...


### PR DESCRIPTION
## Summary
- pass the resource bundle into `FFMpegOptimizer` so progress text can be localized
- replace hard-coded optimisation status with a bundle lookup
- add a localized progress string for optimization to `messages_en.properties`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b2b7ccf148320892690545a0a4bcc)