### PR TITLE
Add German localization resource file

### DIFF
--- a/src/main/resources/locales/messages_de.properties
+++ b/src/main/resources/locales/messages_de.properties
@@ -1,0 +1,211 @@
+menu.file=Datei
+menu.file.add=Hinzuf\u00fcgen...
+menu.file.add.files=Dateien
+menu.file.add.folder=Ordner
+context.files=Dateien
+context.folder=Ordner
+menu.file.remove=Entfernen
+menu.file.clear=Leeren
+menu.file.move_up=Nach oben
+menu.file.move_down=Nach unten
+menu.file.exit=Beenden
+menu.chapter=Kapitel
+menu.chapter.import=Importieren
+menu.chapter.edit=Bearbeiten
+menu.chapter.combine=Zusammenf\u00fcgen
+menu.chapter.split=Teilen
+menu.chapter.move_up=Nach oben
+menu.chapter.move_down=Nach unten
+menu.convert=Konvertieren
+menu.convert.start=Starten
+menu.convert.pause_all=Alle pausieren
+menu.convert.stop_all=Alle stoppen
+menu.convert.clear_queue=Warteschlange leeren
+menu.system=System
+menu.system.settings=Einstellungen
+menu.system.repair=Reparieren
+menu.system.check_version=Nach neuer Version suchen
+menu.about=Hilfe
+menu.about.show_hints=Tipps anzeigen
+menu.about.faq=FAQ
+menu.about.report_bug=Fehler melden
+menu.about.discussions=Diskussionen
+menu.about.website=Webseite
+menu.about.about=Info
+
+dialog.unexpected_error.title=Unerwarteter Fehler
+
+dialog.settings.title=AudioBookConverter Einstellungen
+dialog.settings.header=AudioBookConverter anpassen
+
+dialog.subtracks.title=Unter-Titel erstellen
+dialog.subtracks.header=Einmal nach Sekundenanzahl teilen \noder alle festgelegten Sekunden schneiden
+dialog.subtracks.interval=Intervall w\u00e4hlen, Sekunden
+dialog.subtracks.multiple_segments=Mehrere gleiche Segmente
+dialog.subtracks.auto_chapters=Kapitel automatisch erstellen
+
+dialog.chapter_editor.title=Kapitel bearbeiten
+
+dialog.tip.title=Tipp des Tages...
+
+settings.dark_theme=Dunkles Design
+settings.filename_template.book=Dateinamen-Vorlage Buch
+settings.filename_template.book_part=Dateinamen-Vorlage Buchteil
+settings.filename_template.chapter=Kapitelvorlage
+settings.show_tips=Tipps des Tages anzeigen
+
+button.pause_all=Alle pausieren
+button.resume_all=Alle fortsetzen
+
+dialog.report_bug.title=Fehler melden
+dialog.report_bug.message=Ihre Einstellungen werden in die Zwischenablage kopiert und Sie werden zur GitHub-Issues-Seite weitergeleitet.\nBitte beschreiben Sie Ihr Problem und f\u00fcgen Sie die Einstellungen in den Issue ein.\nHinweis: Ihre Einstellungen k\u00f6nnen sensible Informationen wie Ihren Benutzernamen, Pfade zu Dateien usw. enthalten.\n
+
+dialog.repair.title=Reparieren
+dialog.repair.message=Sind Sie sicher, dass Sie die Einstellungen auf Standard zur\u00fccksetzen m\u00f6chten?\nDas Programm wird geschlossen.
+
+tab.queue=Warteschlange
+tab.files=Audiodateien
+tab.chapters=Kapitel
+tab.book_info=Buchinfo
+tab.art_work=Cover
+tab.quality=Qualit\u00e4t
+
+files.button.add=Hinzuf\u00fcgen
+files.button.remove=Entfernen
+files.button.clear_all=Alles entfernen
+files.button.move_up=Nach oben
+files.button.move_down=Nach unten
+files.button.chapters=Kapitel
+files.button.start=Starten
+
+chapters.button.add=Hinzuf\u00fcgen
+chapters.button.remove=Entfernen
+chapters.button.clear=Leeren
+chapters.button.move_up=Nach oben
+chapters.button.move_down=Nach unten
+chapters.button.edit=Bearbeiten
+chapters.button.split=Teilen
+chapters.button.combine=Zusammenf\u00fcgen
+chapters.button.subtracks=Unter-Titel
+chapters.button.start=Starten
+
+column.chapter.title=Titel
+column.chapter.duration=Dauer
+column.chapter.details=Details
+
+artwork.button.add=Hinzuf\u00fcgen
+artwork.button.paste=Einf\u00fcgen
+artwork.button.remove=Entfernen
+artwork.tooltip.add=Coverbild f\u00fcr das Buch aus externer Datei hinzuf\u00fcgen
+artwork.tooltip.list=Liste der verf\u00fcgbaren Cover f\u00fcr das H\u00f6rbuch verwalten. \nWichtig\: Die meisten Player zeigen nur das erste Cover an, daher ist die Reihenfolge wichtig. \nEntfernen Sie alle, die nicht ins Buch sollen, das spart etwas Speicherplatz.
+artwork.tooltip.moveleft=Bild nach links verschieben
+artwork.tooltip.moveright=Bild nach rechts verschieben
+artwork.tooltip.paste=Coverbild aus der Zwischenablage hinzuf\u00fcgen
+artwork.tooltip.remove=Coverbild aus der Liste entfernen
+
+bookinfo.label.bookno=Buch \#
+bookinfo.label.comment=Kommentar
+bookinfo.label.genre=Genre
+bookinfo.label.narrator=Sprecher
+bookinfo.label.series=Reihe
+bookinfo.label.title=Titel
+bookinfo.label.writer=Autor
+bookinfo.label.year=Jahr
+bookinfo.tooltip.author=Der Buchautor wird im Tag "artist" des H\u00f6rbuchs gespeichert und als Teil des Dateinamens vorgeschlagen
+bookinfo.tooltip.bookno=Die Nummer des Buches in der Reihe wird im Tag "track" des H\u00f6rbuchs gespeichert. Wichtig f\u00fcr die richtige Reihenfolge der Teile in manchen Playern wie Apples Books. Wird als Teil des Dateinamens vorgeschlagen.
+bookinfo.tooltip.comment=Kommentar wird im Tag "comment" des H\u00f6rbuchs gespeichert.
+bookinfo.tooltip.genre=Genre des Buches wird im Tag "genre" des H\u00f6rbuchs gespeichert und NICHT als Teil des Dateinamens vorgeschlagen
+bookinfo.tooltip.narrator=Der Sprecher wird im Tag "composer" des H\u00f6rbuchs gespeichert und als Teil des Dateinamens vorgeschlagen
+bookinfo.tooltip.series=Name der Buchreihe wird im Tag "album" des H\u00f6rbuchs gespeichert und als Teil des Dateinamens vorgeschlagen. B\u00fccher mit gleicher Reihenbezeichnung werden im Apple Books Player zu einem Buch gruppiert und nach Buchnummer sortiert. Wenn leer, wird der Buchtitel f\u00fcr den Tag "album" verwendet. Wird als Teil des Dateinamens vorgeschlagen.
+bookinfo.tooltip.title=Der Buchtitel wird im Tag "title" des H\u00f6rbuchs gespeichert und als Teil des Dateinamens vorgeschlagen
+bookinfo.tooltip.year=Jahr des Verfassens des Buches. Es wird im Tag "date" des H\u00f6rbuchs gespeichert.
+
+mediaplayer.tooltip.playpause=Wiedergabe oder Pause f\u00fcr ausgew\u00e4hlte Audiodatei oder Track im Kapitel
+mediaplayer.tooltip.playtime=Zeigt die aktuelle Zeit im abgespielten Audiotrack an.
+mediaplayer.tooltip.timeslider=Ziehen Sie den Zeitschieberegler, um innerhalb des Audiotracks zu spulen; notieren Sie die genaue Zeit, wenn Sie diesen Track an einer bestimmten Stelle teilen m\u00f6chten.
+mediaplayer.tooltip.totaltime=Zeigt die Gesamtdauer des abgespielten Audiotracks an.
+mediaplayer.tooltip.volumeslider=\u00c4ndert die Lautst\u00e4rke des abgespielten Audiotracks. Beeinflusst nicht die Lautst\u00e4rke des H\u00f6rbuchs.
+
+output.label.format=Format
+output.label.preset=Voreinstellung
+output.label.split=Teilen nach
+output.label.speed=Geschwindigkeit
+output.label.sampling_frequency=Abtastrate, Hz
+output.label.channels=Kan\u00e4le
+output.label.cut_off=Frequenzen h\u00f6her als
+output.label.reencoding=Neu kodieren erzwingen
+output.radio.cbr=Konstante Bitrate, kb/s
+output.radio.vbr=Variable Bitrate, Qualit\u00e4t
+output.button.delete_preset=Voreinstellung l\u00f6schen
+output.tooltip.presets=W\u00e4hlen Sie eine der vorhandenen Voreinstellungen oder erstellen Sie eine neue, indem Sie einfach den Namen eingeben. Voreinstellungen enthalten Kombinationen von Ausgabeparametern f\u00fcr verschiedene Anforderungen.
+output.tooltip.formats=W\u00e4hlen Sie das Ausgabeformat f\u00fcr das H\u00f6rbuch. Am kompatibelsten ist m4b mit AAC-Codierung. Ogg verwendet den effizienteren Codec "opus", wird aber m\u00f6glicherweise nicht von jedem Player unterst\u00fctzt.
+output.tooltip.split=Standard ist die Teilung nach Teilen; normalerweise hat ein Buch nur einen Teil, daher gibt es eine einzelne Ausgabedatei.\nSie k\u00f6nnen das Buch im "Kapitelmodus" in mehrere Teile aufteilen, wenn das Buch sehr gro\u00df ist oder Sie eine Reihenfolge nach Teilen w\u00fcnschen.\nAls Ergebnis erhalten Sie mehrere Ausgabedateien, was n\u00fctzlich sein kann, wenn Ihr Ger\u00e4t wenig Speicher hat oder mit sehr gro\u00dfen Dateien langsam ist.\nDas Teilen nach Kapiteln erstellt eine separate Ausgabedatei f\u00fcr jedes Kapitel, ein g\u00e4ngiges Szenario beim Konvertieren eines m4b-H\u00f6rbuchs in mehrere MP3-Dateien.
+output.tooltip.speed=Geschwindigkeit des H\u00f6rbuchs beim Kodieren \u00e4ndern. Beachten Sie: Dies beeinflusst wahrscheinlich die Gr\u00f6\u00dfe (schneller = kleiner) und die Qualit\u00e4t, sofern Sie keine anderen Parameter anpassen.
+output.tooltip.sampling_frequency=22 kHz sind technisch f\u00fcr die meisten H\u00f6rb\u00fccher ausreichend. Eine h\u00f6here Abtastrate wie 44,1 kHz oder 48 kHz wird empfohlen, um eine bessere Qualit\u00e4t bei Effekten oder Musik zu gew\u00e4hrleisten.\nNiedrigere Abtastraten bringen nahezu lineare Einsparungen bei der Dateigr\u00f6\u00dfe. H\u00f6here Frequenzen liefern f\u00fcr die meisten Benutzer keine merklichen Vorteile.\nDenken Sie daran: Der Frequenzbereich entspricht dem Doppelten der Abtastrate, d.h. bei 22 kHz ist der maximale Bereich auf 11 kHz begrenzt.
+output.tooltip.cut_off=Entfernt Frequenzen, die h\u00f6her als der Grenzwert sind.
+output.tooltip.channels=Anzahl der Audiokan\u00e4le, Standard 2 - Stereo. Einstellung auf 1 Kanal - Mono reduziert Qualit\u00e4t und Gr\u00f6\u00dfe
+output.tooltip.reencode=Soll das Programm eine erneute Kodierung erzwingen? \nAuto - l\u00e4sst das Programm entscheiden: Wenn die Quelldatei mit demselben Codec kodiert ist, werden die Audiotracks nur neu verpackt. Hinweis: Qualitätseinstellungen werden ignoriert, da der Audiostream unver\u00e4ndert verwendet wird.\nAlways - erzwingt erneutes Kodieren, auch wenn der Codec derselbe ist; Qualitätseinstellungen werden ber\u00fccksichtigt.\nAvoid - versucht, erneutes Kodieren f\u00fcr kompatible Codecs im selben Format zu vermeiden, z.B. AAC und ALAC in m4b, Opus und Vorbis in ogg.
+output.tooltip.cbr=In den Modus f\u00fcr konstante Bitrate wechseln. Dieser Modus erm\u00f6glicht eine Vorhersage der Ausgabedateigr\u00f6\u00dfe, allerdings kann die Qualit\u00e4t bei niedrigen Bitraten schwer einzusch\u00e4tzen sein.
+output.tooltip.vbr=In den Modus f\u00fcr variable Bitrate wechseln. Dieser Modus erm\u00f6glicht eine Qualit\u00e4tseinsch\u00e4tzung, allerdings kann die Gr\u00f6\u00dfe der Ausgabedatei je nach Qualit\u00e4t und Komplexit\u00e4t der Ausgangsdatei variieren.
+output.tooltip.bitrate=H\u00f6here Bitrate bedeutet h\u00f6here Qualit\u00e4t und gr\u00f6\u00dfere Dateigr\u00f6\u00dfe. F\u00fcr die meisten m4b-B\u00fccher mit AAC-Codec reichen 64 kb/s aus. W\u00e4hlen Sie h\u00f6here Werte, wenn Musik oder Effekte enthalten sind.
+output.tooltip.vbr_quality=1 ist die niedrigste und 5 die h\u00f6chste Stufe. Es gibt keine standardisierte Definition f\u00fcr Qualit\u00e4t zwischen Codecs. Die exakte Qualit\u00e4t h\u00e4ngt von vielen Faktoren ab, sollte aber w\u00e4hrend des gesamten Buches konsistent bleiben.
+output.tooltip.delete_preset=Nicht mehr ben\u00f6tigte Voreinstellung entfernen.
+
+queue.tooltip.newbook=Neues H\u00f6rbuch aus Ordner oder Dateisatz erstellen. Sie m\u00fcssen mindestens eine Datei ausw\u00e4hlen, um den Prozess zu starten.
+queue.tooltip.pause_all=Konvertierung aller Auftr\u00e4ge pausieren. Dadurch k\u00f6nnen laufende Konvertierungen fertiggestellt werden.
+queue.tooltip.stop_all=Konvertierung aller Auftr\u00e4ge stoppen
+queue.tooltip.clear=Abgeschlossene oder abgebrochene Konvertierungen entfernen
+queue.button.newbook=Neues Buch
+queue.button.pause_all=Alle pausieren
+queue.button.stop_all=Alle stoppen
+queue.button.clear=Abgeschlossene l\u00f6schen
+queue.tooltip.list=Liste zeigt aktive und abgeschlossene Auftr\u00e4ge, mehrere k\u00f6nnen parallel ausgef\u00fchrt werden.
+
+files.tooltip.button_add=Dateien oder Ordner zum aktuellen Buch hinzuf\u00fcgen
+files.tooltip.button_remove=Ausgew\u00e4hlte Dateien aus dem aktuellen Buch entfernen
+files.tooltip.button_clear=Alle Dateien aus der Liste entfernen
+files.tooltip.button_up=Ausgew\u00e4hlte Datei nach oben verschieben
+files.tooltip.button_down=Ausgew\u00e4hlte Datei nach unten verschieben
+files.tooltip.button_chapters=Dateien in Kapitel importieren
+files.tooltip.button_start=Konvertierung des Buches starten
+
+chapters.tooltip.button_add=Dateien oder Ordner zum Buch hinzuf\u00fcgen, neuer Buchteil wird erstellt
+chapters.tooltip.button_remove=Teil, Kapitel oder Track entfernen
+chapters.tooltip.button_clear=Alle Teile, Kapitel, Tracks entfernen
+chatpers.tooltip.button_up=Kapitel nach oben verschieben
+chapters.tooltip.button_down=Kapitel nach unten verschieben
+chapters.tooltip.button_edit=Kapitelname bearbeiten
+chapters.tooltip.button_split=Track ausw\u00e4hlen, an dem Kapitel in zwei Teile geteilt oder wo neuer Buchteil erstellt werden soll
+chapters.tooltip.button_combine=Zwei Kapitel oder Buchteile zu einem zusammenf\u00fcgen
+chapters.tooltip.button_subtrack=Track an bestimmten Zeiten oder Intervallen in zwei oder mehr Unter-Titel teilen
+chapters.tooltip.button_start=Konvertierung des Buches starten
+
+bookinfo.tooltip.tab=Informationen zum Buch ausf\u00fcllen; sie werden in Playern angezeigt
+artwork.tooltip.tab=Cover f\u00fcr das Buch hinzuf\u00fcgen, die in Playern angezeigt werden
+output.tooltip.tab=Qualit\u00e4t und Gr\u00f6\u00dfe des H\u00f6rbuchs feinjustieren
+
+chooser.save_audiobook=H\u00f6rbuch speichern
+chooser.select_files=W\u00e4hlen Sie {0} Dateien zur Konvertierung aus
+chooser.select_folder=Ordner mit {0} Dateien zur Konvertierung ausw\u00e4hlen
+chooser.select_image={0}-Datei ausw\u00e4hlen
+
+notification.conversion_complete.title=AudioBookConverter: Konvertierung abgeschlossen
+notification.conversion_complete.text=Ausgabe gespeichert unter: {0}
+
+alert.update_available.title=Neue Version verf\u00fcgbar!
+alert.update_available.message=M\u00f6chten Sie die neue Version herunterladen?
+
+progress.label.title=Titel
+progress.label.converted_files=Konvertierte Dateien
+progress.label.estimated_size=Gesch\u00e4tzte Dateigr\u00f6\u00dfe
+progress.label.time_elapsed=Verstrichene Zeit
+progress.label.time_remaining=Gesch\u00e4tzte verbleibende Zeit
+progress.button.pause=Pausieren
+progress.button.resume=Fortsetzen
+progress.button.stop=Stoppen
+progress.tooltip.pause=Konvertierung der Dateigruppe pausieren
+progress.tooltip.stop=Konvertierung der Dateigruppe stoppen
+
+chapter.default_title=Kapitel {0}
+
+progress.state.optimizing=Optimiere...


### PR DESCRIPTION
## Summary
- add a German translation resource file alongside existing English localization
- provide German strings for menus, dialogs, tooltips, and notifications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693b32f23c908320b74c9574d02f7827)