### PR TITLE
Localize conversion progress states

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/fx/ConversionProgress.java
+++ b/src/main/java/uk/yermak/audiobookconverter/fx/ConversionProgress.java
@@ -5,6 +5,7 @@ import javafx.beans.property.SimpleLongProperty;
 import javafx.beans.property.SimpleStringProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.yermak.audiobookconverter.AudiobookConverter;
 import uk.yermak.audiobookconverter.ConversionJob;
 import uk.yermak.audiobookconverter.ProgressStatus;
 
@@ -44,6 +45,7 @@ public class ConversionProgress implements Runnable {
         this.conversionJob = conversionJob;
         this.totalFiles = conversionJob.getConvertable().getMedia().size();
         this.totalDuration = conversionJob.getConvertable().getDuration();
+        ResourceBundle resources = AudiobookConverter.getBundle();
         conversionJob.addStatusChangeListener((observable, oldValue, newValue) -> {
             switch (newValue) {
                 case CANCELLED:
@@ -65,11 +67,11 @@ public class ConversionProgress implements Runnable {
                     break;
             }
         });
+        setState(resources.getString("progress.state.converting"));
     }
 
 
     public void run() {
-        state.set("Converting...");
         startTime = System.currentTimeMillis();
 
         filesCount.set(completedFiles + "/" + totalFiles);
@@ -117,7 +119,8 @@ public class ConversionProgress implements Runnable {
         completedFiles++;
         if (paused || cancelled) return;
         if (completedFiles == totalFiles) {
-            state.set("Merging chapters...");
+            ResourceBundle resources = AudiobookConverter.getBundle();
+            setState(resources.getString("progress.state.merging"));
             progress.set(1.0);
         }
         filesCount.set(completedFiles + "/" + totalFiles);
@@ -125,11 +128,13 @@ public class ConversionProgress implements Runnable {
 
     private void finished() {
         finished = true;
-        state.set("Completed!");
+        ResourceBundle resources = AudiobookConverter.getBundle();
+        setState(resources.getString("progress.state.completed"));
     }
     private void error() {
         finished = true;
-        state.set("Error!");
+        ResourceBundle resources = AudiobookConverter.getBundle();
+        setState(resources.getString("progress.state.error"));
     }
 
     private void cancelled() {
@@ -140,19 +145,22 @@ public class ConversionProgress implements Runnable {
         remaining.set(0);
         elapsed.set(0);
         size.set(-1);
-        state.set("Cancelled");
+        ResourceBundle resources = AudiobookConverter.getBundle();
+        setState(resources.getString("progress.state.cancelled"));
     }
 
     private void paused() {
         paused = true;
         pauseTime = System.currentTimeMillis();
-        state.set("Paused");
+        ResourceBundle resources = AudiobookConverter.getBundle();
+        setState(resources.getString("progress.state.paused"));
     }
 
     private void resumed() {
         paused = false;
         pausePeriod += System.currentTimeMillis() - pauseTime;
-        state.set("Converting...");
+        ResourceBundle resources = AudiobookConverter.getBundle();
+        setState(resources.getString("progress.state.converting"));
     }
 
     public void reset() {
@@ -170,3 +178,4 @@ public class ConversionProgress implements Runnable {
         state.set(message);
     }
 }
+import java.util.ResourceBundle;

--- a/src/main/resources/locales/messages_bg.properties
+++ b/src/main/resources/locales/messages_bg.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Пауза на конвертирането за гру�
 progress.tooltip.stop=Спиране на конвертирането за група файлове
 chapter.default_title=Глава {0}
 
+progress.state.converting=Конвертиране...
+progress.state.merging=Сливане на главите...
 progress.state.optimizing=Оптимизация...
+progress.state.completed=Завършено!
+progress.state.error=Грешка!
+progress.state.cancelled=Отменено
+progress.state.paused=На пауза
 
 settings.language=Език (Изисква се рестартиране)
 settings.language.default=Системен по подразбиране

--- a/src/main/resources/locales/messages_by.properties
+++ b/src/main/resources/locales/messages_by.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Паўза для групы файлаў
 progress.tooltip.stop=Спыніць групу файлаў
 chapter.default_title=Раздзел {0}
 
+progress.state.converting=Канвертаванне...
+progress.state.merging=Аб'яднанне раздзелаў...
 progress.state.optimizing=Аптымізацыя...
+progress.state.completed=Завершана!
+progress.state.error=Памылка!
+progress.state.cancelled=Скасавана
+progress.state.paused=Паўза
 
 settings.language=Мова (Патрабуецца перазагрузка)
 settings.language.default=Сістэмная па змаўчанні

--- a/src/main/resources/locales/messages_de.properties
+++ b/src/main/resources/locales/messages_de.properties
@@ -208,7 +208,13 @@ progress.tooltip.stop=Konvertierung der Dateigruppe stoppen
 
 chapter.default_title=Kapitel {0}
 
+progress.state.converting=Konvertiere...
+progress.state.merging=Kapitel werden zusammengeführt...
 progress.state.optimizing=Optimiere...
+progress.state.completed=Abgeschlossen!
+progress.state.error=Fehler!
+progress.state.cancelled=Abgebrochen
+progress.state.paused=Pausiert
 
 settings.language=Sprache (Neustart erforderlich)
 settings.language.default=Systemstandard

--- a/src/main/resources/locales/messages_en.properties
+++ b/src/main/resources/locales/messages_en.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Pause conversion group of files
 progress.tooltip.stop=Stop conversion group of files
 chapter.default_title=Chapter {0}
 
+progress.state.converting=Converting...
+progress.state.merging=Merging chapters...
 progress.state.optimizing=Optimising...
+progress.state.completed=Completed!
+progress.state.error=Error!
+progress.state.cancelled=Cancelled
+progress.state.paused=Paused
 
 settings.language=Language (Requires restart)
 settings.language.default=System default

--- a/src/main/resources/locales/messages_es.properties
+++ b/src/main/resources/locales/messages_es.properties
@@ -196,7 +196,13 @@ progress.tooltip.pause=Pausar el grupo de archivos en conversión
 progress.tooltip.stop=Detener el grupo de archivos en conversión
 chapter.default_title=Capítulo {0}
 
+progress.state.converting=Convirtiendo...
+progress.state.merging=Fusionando capítulos...
 progress.state.optimizing=Optimizando...
+progress.state.completed=¡Completado!
+progress.state.error=¡Error!
+progress.state.cancelled=Cancelado
+progress.state.paused=Pausado
 
 settings.language=Idioma (Requiere reinicio)
 settings.language.default=Predeterminado del sistema

--- a/src/main/resources/locales/messages_fr.properties
+++ b/src/main/resources/locales/messages_fr.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Mettre en pause le groupe de conversions
 progress.tooltip.stop=Arrêter le groupe de conversions
 chapter.default_title=Chapitre {0}
 
+progress.state.converting=Conversion...
+progress.state.merging=Fusion des chapitres...
 progress.state.optimizing=Optimisation...
+progress.state.completed=Terminé !
+progress.state.error=Erreur !
+progress.state.cancelled=Annulé
+progress.state.paused=En pause
 
 settings.language=Langue (Redémarrage requis)
 settings.language.default=Langue système

--- a/src/main/resources/locales/messages_gr.properties
+++ b/src/main/resources/locales/messages_gr.properties
@@ -197,7 +197,13 @@ progress.tooltip.pause=Παύση μετατροπής ομάδας αρχείω
 progress.tooltip.stop=Διακοπή μετατροπής ομάδας αρχείων
 chapter.default_title=Κεφάλαιο {0}
 
+progress.state.converting=Μετατροπή...
+progress.state.merging=Συγχώνευση κεφαλαίων...
 progress.state.optimizing=Βελτιστοποίηση...
+progress.state.completed=Ολοκληρώθηκε!
+progress.state.error=Σφάλμα!
+progress.state.cancelled=Ακυρώθηκε
+progress.state.paused=Σε παύση
 
 settings.language=Γλώσσα (Απαιτείται επανεκκίνηση)
 settings.language.default=Προεπιλογή συστήματος

--- a/src/main/resources/locales/messages_it.properties
+++ b/src/main/resources/locales/messages_it.properties
@@ -201,7 +201,13 @@ progress.tooltip.stop=Ferma la conversione del gruppo di file
 
 chapter.default_title=Capitolo {0}
 
+progress.state.converting=Conversione in corso...
+progress.state.merging=Unione dei capitoli...
 progress.state.optimizing=Ottimizzazione in corso...
+progress.state.completed=Completato!
+progress.state.error=Errore!
+progress.state.cancelled=Annullato
+progress.state.paused=In pausa
 
 settings.language=Lingua (Riavvio richiesto)
 settings.language.default=Lingua di sistema

--- a/src/main/resources/locales/messages_kz.properties
+++ b/src/main/resources/locales/messages_kz.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Файлдар тобын конвертациялауд�
 progress.tooltip.stop=Файлдар тобын конвертациялауды тоқтату
 chapter.default_title=Тарау {0}
 
+progress.state.converting=Түрлендіру...
+progress.state.merging=Тарауларды біріктіру...
 progress.state.optimizing=Оптимизациялау...
+progress.state.completed=Аяқталды!
+progress.state.error=Қате!
+progress.state.cancelled=Бас тартылды
+progress.state.paused=Кідіртілді
 
 settings.language=Тіл (Қайта іске қосу қажет)
 settings.language.default=Жүйелік әдепкі тіл

--- a/src/main/resources/locales/messages_pl.properties
+++ b/src/main/resources/locales/messages_pl.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Wstrzymaj konwersję grupy plików
 progress.tooltip.stop=Zatrzymaj konwersję grupy plików
 chapter.default_title=Rozdział {0}
 
+progress.state.converting=Konwertowanie...
+progress.state.merging=Łączenie rozdziałów...
 progress.state.optimizing=Optymalizowanie...
+progress.state.completed=Zakończono!
+progress.state.error=Błąd!
+progress.state.cancelled=Anulowano
+progress.state.paused=Wstrzymano
 
 settings.language=Język (Wymagane ponowne uruchomienie)
 settings.language.default=Domyślny systemu

--- a/src/main/resources/locales/messages_pt.properties
+++ b/src/main/resources/locales/messages_pt.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Pausar grupo de ficheiros em conversão
 progress.tooltip.stop=Parar grupo de ficheiros em conversão
 chapter.default_title=Capítulo {0}
 
+progress.state.converting=A converter...
+progress.state.merging=A unir capítulos...
 progress.state.optimizing=A otimizar...
+progress.state.completed=Concluído!
+progress.state.error=Erro!
+progress.state.cancelled=Cancelado
+progress.state.paused=Em pausa
 
 
 settings.language=Idioma (Requer reinicialização)

--- a/src/main/resources/locales/messages_ro.properties
+++ b/src/main/resources/locales/messages_ro.properties
@@ -209,7 +209,13 @@ progress.tooltip.stop=Oprește grupul de fișiere în conversie
 
 chapter.default_title=Capitolul {0}
 
+progress.state.converting=Se convertește...
+progress.state.merging=Se îmbină capitolele...
 progress.state.optimizing=Optimizare...
+progress.state.completed=Finalizat!
+progress.state.error=Eroare!
+progress.state.cancelled=Anulat
+progress.state.paused=În pauză
 
 settings.language=Limbă (Necesită repornire)
 settings.language.default=Implicit sistem

--- a/src/main/resources/locales/messages_ru.properties
+++ b/src/main/resources/locales/messages_ru.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Пауза для группы файлов
 progress.tooltip.stop=Остановка группы файлов
 chapter.default_title=Глава {0}
 
+progress.state.converting=Конвертация...
+progress.state.merging=Объединение глав...
 progress.state.optimizing=Оптимизация...
+progress.state.completed=Готово!
+progress.state.error=Ошибка!
+progress.state.cancelled=Отменено
+progress.state.paused=Пауза
 
 settings.language=Язык (Требуется перезагрузка)
 settings.language.default=Системный по умолчанию

--- a/src/main/resources/locales/messages_tr.properties
+++ b/src/main/resources/locales/messages_tr.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Dosya grubunun dönüşümünü duraklat
 progress.tooltip.stop=Dosya grubunun dönüşümünü durdur
 chapter.default_title=Bölüm {0}
 
+progress.state.converting=Dönüştürülüyor...
+progress.state.merging=Bölümler birleştiriliyor...
 progress.state.optimizing=Optimize ediliyor...
+progress.state.completed=Tamamlandı!
+progress.state.error=Hata!
+progress.state.cancelled=İptal edildi
+progress.state.paused=Duraklatıldı
 
 settings.language=Dil (Yeniden başlatma gerekli)
 settings.language.default=Varsayılan sistem dili

--- a/src/main/resources/locales/messages_ua.properties
+++ b/src/main/resources/locales/messages_ua.properties
@@ -182,7 +182,13 @@ progress.tooltip.pause=Пауза для групи файлів
 progress.tooltip.stop=Зупинка групи файлів
 chapter.default_title=Розділ {0}
 
+progress.state.converting=Конвертація...
+progress.state.merging=Об'єднання розділів...
 progress.state.optimizing=Оптимізація...
+progress.state.completed=Завершено!
+progress.state.error=Помилка!
+progress.state.cancelled=Скасовано
+progress.state.paused=Пауза
 
 settings.language=Мова (Потрібне перезавантаження)
 settings.language.default=Системна за замовчуванням


### PR DESCRIPTION
## Summary
- load conversion state labels from the locale bundle instead of hardcoded strings
- add localized progress state texts for all supported languages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f1ffea28883208a10eabbeda815ed)