### PR TITLE
Make file list fill available space

### DIFF
--- a/src/main/java/uk/yermak/audiobookconverter/fx/FilesController.java
+++ b/src/main/java/uk/yermak/audiobookconverter/fx/FilesController.java
@@ -325,7 +325,8 @@ public class FilesController extends VBox {
         filesBar.getItems().addAll(addButton, removeButton, new Separator(), clearButton, new Separator(), moveUp, moveDown,
                 new Separator(), importButton, new Separator(), startButton);
 
-        fileList.setPrefHeight(screen.getVisualBounds().getHeight() * 0.25);
+        fileList.setMaxHeight(Double.MAX_VALUE);
+        VBox.setVgrow(fileList, Priority.ALWAYS);
         VBox filesBox = new VBox(filesBar, fileList);
         filesTab.setContent(filesBox);
     }


### PR DESCRIPTION
## Summary
- allow the files list view to grow with its container
- prevent the file list from forcing a fixed height

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693f4c8c73ac8320ac20e2ab824be206)